### PR TITLE
chore: Pin `fastmcp` dependency to version `2.14.5` due to a circular…

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
   "celery[redis]>=5.5.3",
   "crawl4ai>=0.8.0,<0.9.0",
   "fastapi>=0.121.0",
-  "fastmcp>=2.14.0",
+  "fastmcp==2.14.5",
   "pgvector>=0.4.1",
   "pydantic-ai-slim[bedrock]>=1.61.0",
   "psycopg[binary]>=3.2.13",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -710,7 +710,7 @@ requires-dist = [
     { name = "celery", extras = ["redis"], specifier = ">=5.5.3" },
     { name = "crawl4ai", specifier = ">=0.8.0,<0.9.0" },
     { name = "fastapi", specifier = ">=0.121.0" },
-    { name = "fastmcp", specifier = ">=2.14.0" },
+    { name = "fastmcp", specifier = "==2.14.5" },
     { name = "pgvector", specifier = ">=0.4.1" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.13" },
     { name = "pydantic-ai-slim", extras = ["bedrock"], specifier = ">=1.61.0" },


### PR DESCRIPTION
… reference bug